### PR TITLE
Add server-timing middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12500,7 +12500,7 @@
     },
     "node_modules/on-headers": {
       "version": "1.0.2",
-      "resolved": "https://nexus.booxdev.com/repository/npm-all/on-headers/-/on-headers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "license": "MIT",
       "engines": {
@@ -27247,7 +27247,7 @@
     },
     "on-headers": {
       "version": "1.0.2",
-      "resolved": "https://nexus.booxdev.com/repository/npm-all/on-headers/-/on-headers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "node-cache": "^5.1.2",
         "node-fetch": "^2.6.7",
         "normalize.css": "^8.0.1",
+        "on-headers": "^1.0.2",
         "pretty-error": "^4.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -12499,8 +12500,9 @@
     },
     "node_modules/on-headers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "resolved": "https://nexus.booxdev.com/repository/npm-all/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -27245,7 +27247,7 @@
     },
     "on-headers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "resolved": "https://nexus.booxdev.com/repository/npm-all/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "node-cache": "^5.1.2",
     "node-fetch": "^2.6.7",
     "normalize.css": "^8.0.1",
+    "on-headers": "^1.0.2",
     "pretty-error": "^4.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/js/util/serverTiming.js
+++ b/src/js/util/serverTiming.js
@@ -21,5 +21,4 @@ const createServerTiming = (name) => (_req, res) => {
   return [start, stop];
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export default createServerTiming;

--- a/src/js/util/serverTiming.js
+++ b/src/js/util/serverTiming.js
@@ -1,0 +1,25 @@
+import onHeaders from "on-headers";
+
+// create server-timing entry for duration of server-side rendering
+const createServerTiming = (name) => (_req, res) => {
+  // eslint-disable-next-line no-param-reassign
+  const start = process.hrtime();
+
+  const stop = ({ description, precision } = {}) => {
+    const end = process.hrtime(start);
+    onHeaders(res, () => {
+      const duration = end[0] * 1000 + end[1] / 1000000;
+      res.append(
+        "Server-Timing",
+        `${name};dur=${duration.toFixed(precision || 1)}${
+          description ? `;desc="${description}"` : ""
+        }`
+      );
+    });
+  };
+
+  return [start, stop];
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export default createServerTiming;

--- a/src/server.js
+++ b/src/server.js
@@ -80,9 +80,11 @@ app.use((req, res, next) => {
     error.status = 404;
     return next(error);
   }
-  // middleware to render server side HTML
-  return handleRender(req, res, next);
+
+  return next();
 });
+
+app.use(handleRender);
 
 const prettyError = new PrettyError();
 prettyError.skipNodeFiles();


### PR DESCRIPTION
Add middleware to measure server process time and return it as server-timing response header.

**Usage**
```
const [startTime, setServerTiming] = createServerTiming("render")(req, res, next);
doSomething();
setServerTiming({ description: "Time to render page", precision: 3 });
```

**Response**
```
Server-Timing: render;dur=135.8
Server-Timing: routesData;dur=117.2
Server-Timing: routes;dur=1.3
```